### PR TITLE
Fix an odd bug that was happening on safari and iPhones 

### DIFF
--- a/src/components/Post.module.scss
+++ b/src/components/Post.module.scss
@@ -82,15 +82,16 @@
     margin-top: 1rem;
   }
 
-  footer {
-    visibility: hidden;
-    max-height: 0;
-  }
+  //This cause a bug on Apple devices (Safari and iPhone Browsers):
+  // footer {
+  //   visibility: hidden;
+  //   max-height: 0;
+  // }
 
-  &:focus-within footer {
-    visibility: visible;
-    max-height: none;
-  }
+  // &:focus-within footer {
+  //   visibility: visible;
+  //   max-height: none;
+  // }
 
   button {
     padding: 1rem 1.5rem;
@@ -110,7 +111,7 @@
 
     &:disabled {
       opacity: 0.7;
-      cursor: not-allowed;
+      // cursor: not-allowed;
     }
   }
 


### PR DESCRIPTION
This was a css bug that caused the user be unable to comment in the post, it worked totally fine on Chrome and android, but not on safari and Iphone browsers.

Suggestion for future updates: Define the css that is meant to be used on apple devices and another one to Windows/Android devices.